### PR TITLE
Update u-posAbsoluteCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Basic visual tests are in `test/index.html`.
 
 * Google Chrome (latest)
 * Opera (latest)
-* Firefox 4+
+* Firefox (latest)
 * Safari 5+
-* Internet Explorer 8+
+* Internet Explorer 9+
+* Android 2.3+
+* iOS 5.1+
+* Windows Phone 8.1

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Read more about [SUIT CSS's design principles](https://github.com/suitcss/suit/)
 ## Available classes
 
 * `u-posAbsolute` - Absolutely position an element.
-* `u-posAbsoluteCenter` - Absolutely position and center an element.
+* `u-posAbsoluteCenter` - Absolutely position and centre an element.
 * `u-posFit` - Fit an element to the dimensions of its parent
 * `u-posFullScreen` - Fixes an element over the viewport
 * `u-posFixed` - Fixed position an element.
+* `u-posFixedCenter` - Fix an element in the centre of the viewport
 * `u-posRelative` - Relatively position an element.
 * `u-posStatic` - Static position an element.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Read more about [SUIT CSS's design principles](https://github.com/suitcss/suit/)
 
 ## Usage
 
+### Creating a dialog overlay
+
+``` html
+<div role="dialog" class="Dialog u-posFixedCenter">
+  <img src="{src}" alt="" />
+</div>
+<div class="Cover u-posFullScreen"></div>
+```
+
+[Demo](http://codepen.io/simonsmith/pen/qbGaPK)
+
 Please refer to the README for [SUIT CSS utils](https://github.com/suitcss/utils/)
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Read more about [SUIT CSS's design principles](https://github.com/suitcss/suit/)
 ## Available classes
 
 * `u-posAbsolute` - Absolutely position an element.
-* `u-posAbsoluteCenter` - Absolutely position and center an element (requires explicit height).
+* `u-posAbsoluteCenter` - Absolutely position and center an element.
+* `u-posFit` - Fit an element to the dimensions of its parent
 * `u-posFullScreen` - Fixes an element over the viewport
 * `u-posFixed` - Fixed position an element.
 * `u-posRelative` - Relatively position an element.

--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,3 @@
+IE 9
+> 1%
+Last 2 versions

--- a/lib/position.css
+++ b/lib/position.css
@@ -1,3 +1,5 @@
+.u-posFit,
+.u-posAbsoluteCenter,
 .u-posAbsolute {
   position: absolute !important;
 }
@@ -7,23 +9,18 @@
  * ancestor.
  */
 
+.u-posFixedCenter,
 .u-posAbsoluteCenter {
   left: 50% !important;
-  position: absolute !important;
   top: 50% !important;
   transform: translate(-50%, -50%) !important;
 }
 
-/**
- * Fits an element to the dimensions of its nearest relatively-positioned
- * ancestor.
- */
-
-.u-posFit {
+.u-posFit,
+.u-posFullScreen {
   bottom: 0 !important;
   left: 0 !important;
   margin: auto !important;
-  position: absolute !important;
   right: 0 !important;
   top: 0 !important;
 }
@@ -33,22 +30,11 @@
  *    reasons.
  */
 
+.u-posFullScreen,
+.u-posFixedCenter,
 .u-posFixed {
   backface-visibility: hidden; /* 1 */
   position: fixed !important;
-}
-
-/**
- * Cover the viewport
- */
-
-.u-posFullScreen {
-  backface-visibility: hidden; /* 1 */
-  bottom: 0 !important;
-  left: 0 !important;
-  position: fixed !important;
-  right: 0 !important;
-  top: 0 !important;
 }
 
 .u-posRelative {

--- a/lib/position.css
+++ b/lib/position.css
@@ -3,18 +3,15 @@
 }
 
 /**
- * Pins to all corners by default. But when a width and/or height are
- * provided, the element will be centered in its nearest relatively-positioned
+ * Element will be centered to its nearest relatively-positioned
  * ancestor.
  */
 
 .u-posAbsoluteCenter {
-  bottom: 0 !important;
-  left: 0 !important;
-  margin: auto !important;
+  left: 50% !important;
   position: absolute !important;
-  right: 0 !important;
-  top: 0 !important;
+  top: 50% !important;
+  transform: translate(-50%, -50%) !important;
 }
 
 /**

--- a/lib/position.css
+++ b/lib/position.css
@@ -15,6 +15,20 @@
 }
 
 /**
+ * Fits an element to the dimensions of its nearest relatively-positioned
+ * ancestor.
+ */
+
+.u-posFit {
+  bottom: 0 !important;
+  left: 0 !important;
+  margin: auto !important;
+  position: absolute !important;
+  right: 0 !important;
+  top: 0 !important;
+}
+
+/**
  * 1. Make sure fixed elements are promoted into a new layer, for performance
  *    reasons.
  */

--- a/test/index.html
+++ b/test/index.html
@@ -42,10 +42,11 @@
   <h2 class="Test-describe">.u-posAbsoluteCenter</h2>
   <h3 class="Test-it">absolutely centers the element</h3>
   <div class="Test-run" id="center">
-    <span class="u-posAbsoluteCenter u-highlight"></span>
-  </div>
-  <div class="Test-run" id="center">
     <span class="u-posAbsoluteCenter u-highlight Box"></span>
+  </div>
+  <h3 class="Test-it">centers without width and height</h3>
+  <div class="Test-run" id="center">
+    <span class="u-posAbsoluteCenter u-highlight">Testing</span>
   </div>
 
   <h2 class="Test-describe">.u-posFullScreen</h2>

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,7 @@
 
   .Cover {
     background-color: rgba(0,0,0,.8);
+    z-index: 1;
     display: none;
   }
 </style>
@@ -55,5 +56,11 @@
     <label for="showblock">Toggle</label>
     <input type="checkbox" id="showblock" />
     <div class="Cover u-posFullScreen"></div>
+  </div>
+
+  <h2 class="Test-describe">.u-posFit</h2>
+  <h3 class="Test-it">fits element to its parent</h3>
+  <div class="Test-run" id="center">
+    <span class="u-posFit u-highlight"></span>
   </div>
 </div>

--- a/test/index.html
+++ b/test/index.html
@@ -26,7 +26,11 @@
     z-index: 2;
   }
 
-  #showblock:checked + .Cover {
+  #showblock + div {
+    display: none;
+  }
+
+  #showblock:checked + div {
     display: block;
   }
 
@@ -56,6 +60,14 @@
     <label for="showblock">Toggle</label>
     <input type="checkbox" id="showblock" />
     <div class="Cover u-posFullScreen"></div>
+  </div>
+
+  <h2 class="Test-describe">.u-posFixedCenter</h2>
+  <h3 class="Test-it">fix and centre an element in the viewport</h3>
+  <div class="Test-run">
+    <label for="showblock">Toggle</label>
+    <input type="checkbox" id="showblock" />
+    <div class="u-posFixedCenter u-highlight">Text in the centre</div>
   </div>
 
   <h2 class="Test-describe">.u-posFit</h2>


### PR DESCRIPTION
Fixes #4 

This updates `u-posAbsoluteCenter` to use `transform` and adds a separate ruleset for making an element fit to the size of its parent.

@timkelty What do you think about the naming here? I picked `u-posFit` but `u-posCover` was another option. 

Tested on various devices and updated the browser list too